### PR TITLE
Add support for fetching offerings across all platforms

### DIFF
--- a/apps/offering/src/offering.controller.ts
+++ b/apps/offering/src/offering.controller.ts
@@ -27,6 +27,11 @@ export class OfferingController {
     return this.offeringService.getOfferingForPlatform(params);
   }
 
+  @MessagePattern(OfferingTopics.GET_OFFERING_FOR_ALL_PLATFORMS)
+  getAllPlatformsOffering(@RpcPayload() query: { withDependencies?: boolean }) {
+    return this.offeringService.getAllPlatformsOffering(query);
+  }
+
   @MessagePattern(OfferingTopics.GET_OFFERING_FOR_DEVICE_TYPE)
   getOfferingForDeviceType(@RpcPayload() query: DeviceTypeOfferingFilterQuery) {
     return this.offeringService.getOfferingForDeviceType(query);

--- a/apps/offering/src/offering.service.ts
+++ b/apps/offering/src/offering.service.ts
@@ -937,6 +937,21 @@ export class OfferingService implements OnModuleInit {
     return platformOffering;
   }
 
+  async getAllPlatformsOffering(options?: { withDependencies?: boolean }): Promise<PlatformOfferingDto[]> {
+    this.logger.log('getAllPlatformsOffering: fetching offering for all platforms');
+    const platforms = await this.platformRepo.find();
+    const results = await Promise.allSettled(
+      platforms.map(p =>
+        this.getOfferingForPlatform(
+          { platformIdentifier: p.id, withDependencies: options?.withDependencies ?? true },
+        ),
+      ),
+    );
+    return results
+      .filter((r): r is PromiseFulfilledResult<PlatformOfferingDto> => r.status === 'fulfilled')
+      .map(r => r.value);
+  }
+
   async getOfferingForDeviceType(
     query: DeviceTypeOfferingFilterQuery,
   ): Promise<DeviceTypeOfferingDto> {

--- a/libs/common/src/microservice-client/topics/topics.enums.ts
+++ b/libs/common/src/microservice-client/topics/topics.enums.ts
@@ -81,6 +81,7 @@ export const OfferingTopics = {
     GET_OFFERING_FOR_DEVICE_TYPE: `getapp-offering.get-offering-for-device-type${region}`,
     GET_OFFERING_FOR_PROJECT: `getapp-offering.get-offering-for-project${region}`,
     GET_OFFERING_FOR_ALL_PROJECTS: `getapp-offering.get-offering-for-all-project${region}`,
+    GET_OFFERING_FOR_ALL_PLATFORMS: `getapp-offering.get-offering-for-all-platforms${region}`,
     GET_OFFER_OF_COMP: `getapp-offering.get-offering-of-comp${region}`,
 
     // Policies


### PR DESCRIPTION
This pull request adds support for fetching offering data across all platforms in the offering service. The main changes include introducing a new message pattern and topic for this functionality, as well as implementing the corresponding service method.

**New functionality for fetching offerings for all platforms:**

* Added a new message pattern handler `getAllPlatformsOffering` to the `OfferingController`, which responds to the `GET_OFFERING_FOR_ALL_PLATFORMS` topic and retrieves offering data for all platforms, optionally including dependencies.
* Implemented the `getAllPlatformsOffering` method in `OfferingService`, which fetches all platforms from the repository and retrieves their offerings in parallel using `Promise.allSettled`, returning only successful results.

**Microservice topic update:**

* Added the `GET_OFFERING_FOR_ALL_PLATFORMS` topic to the `OfferingTopics` enum in the shared library for consistent messaging across services.