### PR TITLE
fixed a bug with fetching dependencies fetching - there was a bug in the recusive function

### DIFF
--- a/apps/offering/src/offering.service.ts
+++ b/apps/offering/src/offering.service.ts
@@ -1290,16 +1290,10 @@ export class OfferingService implements OnModuleInit {
     return componentOffering;
   }
 
-  private async fetchReleasesByCatalogIds(catalogIds: string[], includeDependencies: boolean = false, visited: Set<string> = new Set()): Promise<ReleaseEntity[]> {
-    // Filter out already visited catalog IDs to avoid infinite loops
-    const toFetch = catalogIds.filter(id => !visited.has(id));
-
-    if (toFetch.length === 0) {
+  private async fetchReleasesByCatalogIds(catalogIds: string[], includeDependencies: boolean = false, ancestors: Set<string> = new Set()): Promise<ReleaseEntity[]> {
+    if (catalogIds.length === 0) {
       return [];
     }
-
-    // Mark these as visited
-    toFetch.forEach(id => visited.add(id));
 
     const select: any = {
       project: { id: true, name: true, projectType: true },
@@ -1319,7 +1313,7 @@ export class OfferingService implements OnModuleInit {
       select,
       where: {
         status: ReleaseStatusEnum.RELEASED,
-        catalogId: In(toFetch),
+        catalogId: In(catalogIds),
       },
       relations,
     });
@@ -1328,9 +1322,17 @@ export class OfferingService implements OnModuleInit {
     if (includeDependencies) {
       for (const release of releases) {
         if (release.dependencies?.length > 0) {
-          const dependencyCatalogIds = release.dependencies.map(d => d.catalogId);
-          const nestedReleases = await this.fetchReleasesByCatalogIds(dependencyCatalogIds, true, visited);
-          release.dependencies = nestedReleases;
+          // Use ancestors (current path) rather than all-visited to allow diamond/shared deps
+          // while still preventing true circular references (e.g. A -> B -> A)
+          const dependencyCatalogIds = release.dependencies
+            .map(d => d.catalogId)
+            .filter(id => !ancestors.has(id));
+          if (dependencyCatalogIds.length > 0) {
+            const newAncestors = new Set([...ancestors, release.catalogId]);
+            release.dependencies = await this.fetchReleasesByCatalogIds(dependencyCatalogIds, true, newAncestors);
+          } else {
+            release.dependencies = [];
+          }
         }
       }
     }


### PR DESCRIPTION
The fix changes the semantics of cycle detection from "all nodes ever seen" to "ancestors in the current traversal path":

**Before:** visited accumulated every catalog ID fetched at any level. When 93.Dependecies2@1.0.1 appeared as a top-level release, it was added to visited, so when 91.Dependecies1@2.0.1 later tried to fetch it as a dependency, it was filtered out and returned [].

**After:** ancestors tracks only the nodes along the current path. Each dependency lookup gets a new ancestors set containing the current release + its ancestors. This means:

A release that is both top-level and a dependency is fetched correctly in both contexts.
True circular references (A → B → A) are still prevented because A is in the ancestors set when B tries to recurse back to A.