### PR TITLE
Add support for fetching offerings for all device types

### DIFF
--- a/apps/offering/src/offering.controller.ts
+++ b/apps/offering/src/offering.controller.ts
@@ -32,6 +32,11 @@ export class OfferingController {
     return this.offeringService.getAllPlatformsOffering(query);
   }
 
+  @MessagePattern(OfferingTopics.GET_OFFERING_FOR_ALL_DEVICE_TYPES)
+  getAllDeviceTypesOffering(@RpcPayload() query: { withDependencies?: boolean }) {
+    return this.offeringService.getAllDeviceTypesOffering(query);
+  }
+
   @MessagePattern(OfferingTopics.GET_OFFERING_FOR_DEVICE_TYPE)
   getOfferingForDeviceType(@RpcPayload() query: DeviceTypeOfferingFilterQuery) {
     return this.offeringService.getOfferingForDeviceType(query);

--- a/apps/offering/src/offering.service.ts
+++ b/apps/offering/src/offering.service.ts
@@ -943,6 +943,21 @@ export class OfferingService implements OnModuleInit {
       .map(r => r.value);
   }
 
+  async getAllDeviceTypesOffering(options?: { withDependencies?: boolean }): Promise<DeviceTypeOfferingDto[]> {
+    this.logger.log('getAllDeviceTypesOffering: fetching offering for all device types');
+    const deviceTypes = await this.deviceTypeRepo.find();
+    const results = await Promise.allSettled(
+      deviceTypes.map(dt =>
+        this.getOfferingForDeviceType(
+          { deviceTypeIdentifier: dt.id, withDependencies: options?.withDependencies ?? true },
+        ),
+      ),
+    );
+    return results
+      .filter((r): r is PromiseFulfilledResult<DeviceTypeOfferingDto> => r.status === 'fulfilled')
+      .map(r => r.value);
+  }
+
   async getOfferingForDeviceType(
     query: DeviceTypeOfferingFilterQuery,
   ): Promise<DeviceTypeOfferingDto> {

--- a/libs/common/src/microservice-client/topics/topics.enums.ts
+++ b/libs/common/src/microservice-client/topics/topics.enums.ts
@@ -83,6 +83,7 @@ export const OfferingTopics = {
     GET_OFFERING_FOR_PROJECT: `getapp-offering.get-offering-for-project${region}`,
     GET_OFFERING_FOR_ALL_PROJECTS: `getapp-offering.get-offering-for-all-project${region}`,
     GET_OFFERING_FOR_ALL_PLATFORMS: `getapp-offering.get-offering-for-all-platforms${region}`,
+    GET_OFFERING_FOR_ALL_DEVICE_TYPES: `getapp-offering.get-offering-for-all-device-types${region}`,
     GET_OFFER_OF_COMP: `getapp-offering.get-offering-of-comp${region}`,
 
     // Policies


### PR DESCRIPTION
This pull request introduces a new feature to support fetching offerings for all device types at once, in addition to the existing per-device-type queries. The changes include updates to the controller, service, and topics enum to enable this functionality.

**New endpoint and service logic for device type offerings:**

- Controller: Added a new message handler `getAllDeviceTypesOffering` in `OfferingController` to handle requests for offerings across all device types.
- Service: Implemented `getAllDeviceTypesOffering` in `OfferingService` to retrieve offerings for all device types, using `Promise.allSettled` to aggregate results and log the operation.

**Microservice communication:**

- Topics Enum: Added `GET_OFFERING_FOR_ALL_DEVICE_TYPES` to `OfferingTopics` for use in microservice messaging.